### PR TITLE
Update disable Alfred hat on window instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ This variant uses [Noto Sans](https://fonts.google.com/specimen/Noto+Sans) which
 
 ## Suggested configuration
 
-Disable the Alfred hat logo by unchecking: `Alfred Preferences › Appearance › Options › Hide hat on Alfred window`
+Disable the Alfred hat logo by checking: `Alfred Preferences › Appearance › Options › Hide hat on Alfred window`
 
-Disable result shortcuts by unchecking: : `Alfred Preferences › Appearance › Options › Hide result shortcuts`
+Disable result shortcuts by unchecking: `Alfred Preferences › Appearance › Options › Hide result shortcuts`
 
 Simplify results by switching the result subtext to "Only for Alternative Actions".
 


### PR DESCRIPTION
Quick one, but the check/uncheck instructions are backwards. Need to check to hide the Alfred hat:

![image](https://user-images.githubusercontent.com/343097/102678095-049a9100-415b-11eb-8235-2b6f3bbe6ca4.png)
